### PR TITLE
ImportError issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ with open("requirements.txt") as f:
 
 setup(
     name='paydunya',
-    version=__import__('paydunya').__version__,
+    version='1.0.6',
     author='PAYDUNYA',
     author_email='paydunya@paydunya.com',
     packages=['paydunya'],


### PR DESCRIPTION
The pip installation of paydunya raises an ImportError exception due to an import module inside the setup.py file. I fixed it by replacing the importation by the excepted value.